### PR TITLE
renamed method that was wrongly named

### DIFF
--- a/src/main/java/com/watchdog/GreetingController.java
+++ b/src/main/java/com/watchdog/GreetingController.java
@@ -19,7 +19,7 @@ public class GreetingController {
     }
 
     @RequestMapping(value="/register", method=RequestMethod.GET)
-    public String index(User user) {
+    public String register(User user) {
         return "register";
     }
 


### PR DESCRIPTION
Overlooked a method name. The register page method was called index(). Renamed to register()
